### PR TITLE
Implement revocation API.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,5 +3,10 @@
  */
 'use strict';
 
+require('bedrock-mongodb');
+
+// load config defaults
+require('./config');
+
 // module API
 module.exports = require('./storage');

--- a/lib/storage-revocations.js
+++ b/lib/storage-revocations.js
@@ -1,0 +1,97 @@
+/*!
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const assert = require('assert-plus');
+const bedrock = require('bedrock');
+const database = require('bedrock-mongodb');
+const {promisify} = require('util');
+const {util: {BedrockError}} = bedrock;
+
+bedrock.events.on('bedrock-mongodb.ready', async () => {
+  await promisify(database.openCollections)(['zcap-revocation']);
+  await promisify(database.createIndexes)([{
+    collection: 'zcap-revocation',
+    fields: {delegator: 1, id: 1},
+    options: {unique: true, background: false}
+  }]);
+});
+
+/**
+ * Inserts an revocation into storage.
+ *
+ * @param {string} controller - The ID of the entity storing the revocation.
+ * @param {Object} capability - The capability to insert.
+ *
+ * @return {Promise<Object>} the database record.
+ */
+exports.insert = async ({delegator, capability} = {}) => {
+  assert.string(delegator, 'delegator');
+  assert.object(capability, 'capability');
+  assert.string(capability.id, 'capability.id');
+
+  const now = Date.now();
+  const meta = {
+    delegator,
+    created: now, updated: now
+  };
+  const record = {
+    id: database.hash(capability.id),
+    delegator: database.hash(delegator),
+    capability,
+    meta,
+  };
+
+  try {
+    const result = await database.collections['zcap-revocation'].insert(
+      record, database.writeOptions);
+    return result.ops[0];
+  } catch(e) {
+    if(!database.isDuplicateError(e)) {
+      throw e;
+    }
+    throw new BedrockError(
+      'Duplicate revocation.',
+      'DuplicateError', {
+        public: true,
+        httpStatusCode: 409
+      }, e);
+  }
+};
+
+/**
+ * A summary of a capability.
+ *
+ * @typedef {Object} CapabilitySummary
+ * @property {string} capabilityId - The value of `capability.id`.
+ * @property {string} delegator - The delegator of the capability.
+ */
+
+/**
+ * Determine if any of the provided capabilities have been revoked.
+ *
+ * @param {Object} options - The options to use.
+ * @param {CapabilitySummary[]} capabilities  - The capabilities to check.
+ *
+ * @return {Promise<boolean>} At least one of the capabilities has been revoked.
+ */
+exports.isRevoked = async ({capabilities}) => {
+  assert.arrayOfObject(capabilities, 'capabilities');
+
+  const query = {$or: []};
+
+  for(const c of capabilities) {
+    assert.string(c.capabilityId, 'capabilityId');
+    assert.string(c.delegator, 'delegator');
+    query.$or.push({
+      id: database.hash(c.capabilityId),
+      delegator: database.hash(c.delegator),
+    });
+  }
+
+  const revoked = await database.collections['zcap-revocation'].findOne(
+    query, {_id: 0, id: 1});
+
+  return !!revoked;
+};

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -20,7 +20,7 @@ const zcaps = api.zcaps = {};
 bedrock.events.on('bedrock-mongodb.ready', async () => {
   /* Note: There are two capability collections:
 
-  1. The `authorization` collection is used to store capabilities that are
+  1. The `zcap-authorization` collection is used to store capabilities that are
   actively authorized for use. The authorizing party (stored as the
   `controller`) writes these capabilities to this collection after an
   application ensures they are permitted to do so for a given
@@ -30,11 +30,14 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   active capabilities when verifying a capability invocation by querying for
   the capability by its ID and invocationTarget.
 
-  2. The `zcap` collection is used to store capabilities for an invoker to
-  later invoke.
+  2. The `zcap-storage` collection is used to store capabilities for an
+  invoker to later invoke.
 
   */
-  await promisify(database.openCollections)(['authorization', 'zcap']);
+  await promisify(database.openCollections)([
+    'zcap-authorization',
+    'zcap-storage'
+  ]);
 
   await promisify(database.createIndexes)([{
     // cover queries by invocationTarget and id; as this is a unique index and
@@ -42,31 +45,31 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     // invocationTarget to prevent squatting on IDs and assume applications
     // will ensure authorizations written to storage were written by parties
     // authorized to delegate the zcap for the invocationTarget
-    collection: 'authorization',
+    collection: 'zcap-authorization',
     fields: {invocationTarget: 1, id: 1},
     options: {unique: true, background: false}
   }, {
     // cover queries by controller of the authorization and id; allows for
     // controllers to see all of the zcaps they have authorized via storage
-    collection: 'authorization',
+    collection: 'zcap-authorization',
     fields: {controller: 1, id: 1},
     options: {unique: true, background: false}
   }, {
     // enable queries by controller and reference ID (reference IDs are
     // scoped to controllers)
-    collection: 'zcap',
+    collection: 'zcap-storage',
     fields: {controller: 1, referenceId: 1},
     options: {unique: true, background: false}
   }, {
     // enable queries by controller and id; as this is a unique index and IDs
     // are controlled by the zcap creator, we scope the index to the controller
     // to prevent entities from squatting on IDs
-    collection: 'zcap',
+    collection: 'zcap-storage',
     fields: {controller: 1, id: 1},
     options: {unique: true, background: false}
   }, {
     // enable queries by controller and invoker
-    collection: 'zcap',
+    collection: 'zcap-storage',
     fields: {controller: 1, invoker: 1},
     options: {unique: false, background: false}
   }]);
@@ -113,7 +116,7 @@ authorizations.insert = async ({controller, capability} = {}) => {
   };
 
   try {
-    const result = await database.collections.authorization.insert(
+    const result = await database.collections['zcap-authorization'].insert(
       record, database.writeOptions);
     return result.ops[0];
   } catch(e) {
@@ -172,7 +175,7 @@ authorizations.get = async ({id, controller, invocationTarget} = {}) => {
     }
   }
 
-  const record = await database.collections.authorization.findOne(
+  const record = await database.collections['zcap-authorization'].findOne(
     query, {_id: 0, authorization: 1, meta: 1});
   if(!record) {
     throw new BedrockError(
@@ -194,7 +197,7 @@ authorizations.get = async ({id, controller, invocationTarget} = {}) => {
  * @return {Promise<Array>} resolves to the records that matched the query.
  */
 authorizations.find = async ({query = {}, fields = {}, options = {}}) => {
-  return database.collections.authorization.find(
+  return database.collections['zcap-authorization'].find(
     query, fields, options).toArray();
 };
 
@@ -212,7 +215,7 @@ authorizations.remove = async ({controller, id} = {}) => {
   assert.string(controller, 'controller');
   assert.string(id, 'id');
 
-  const result = await database.collections.authorization.remove(
+  const result = await database.collections['zcap-authorization'].remove(
     {controller: database.hash(controller), id: database.hash(id)});
   return result.result.n !== 0;
 };
@@ -247,7 +250,7 @@ zcaps.insert = async ({controller, referenceId, capability} = {}) => {
   };
 
   try {
-    const result = await database.collections.zcap.insert(
+    const result = await database.collections['zcap-storage'].insert(
       record, database.writeOptions);
     return result.ops[0];
   } catch(e) {
@@ -288,7 +291,7 @@ zcaps.get = async ({controller, id, referenceId} = {}) => {
   if(referenceId) {
     query.referenceId = database.hash(referenceId);
   }
-  const record = await database.collections.zcap.findOne(
+  const record = await database.collections['zcap-storage'].findOne(
     query, {_id: 0, capability: 1, meta: 1});
   if(!record) {
     throw new BedrockError(
@@ -310,7 +313,7 @@ zcaps.get = async ({controller, id, referenceId} = {}) => {
  * @return {Promise<Array>} resolves to the records that matched the query.
  */
 zcaps.find = async ({query = {}, fields = {}, options = {}}) => {
-  return database.collections.zcap.find(
+  return database.collections['zcap-storage'].find(
     query, fields, options).toArray();
 };
 
@@ -340,6 +343,6 @@ zcaps.remove = async ({controller, id, referenceId} = {}) => {
   if(referenceId) {
     query.referenceId = database.hash(referenceId);
   }
-  const result = await database.collections.zcap.remove(query);
+  const result = await database.collections['zcap-storage'].remove(query);
   return result.result.n !== 0;
 };

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -7,16 +7,14 @@ const assert = require('assert-plus');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
 const {promisify} = require('util');
-const {BedrockError} = bedrock.util;
-
-// load config defaults
-require('./config');
+const {util: {BedrockError}} = bedrock;
 
 // module API
 const api = {};
 module.exports = api;
 
 const authorizations = api.authorizations = {};
+api.revocations = require('./storage-revocations');
 const zcaps = api.zcaps = {};
 
 bedrock.events.on('bedrock-mongodb.ready', async () => {
@@ -83,7 +81,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  *
  * @return {Promise<Object>} resolves to the database record.
  */
-authorizations.insert = async ({controller, capability}) => {
+authorizations.insert = async ({controller, capability} = {}) => {
   assert.string(controller, 'controller');
   assert.object(capability, 'capability');
   assert.string(capability.id, 'capability.id');
@@ -143,7 +141,7 @@ authorizations.insert = async ({controller, capability}) => {
  *
  * @return {Promise<Object>} resolves to `{capability, meta}`.
  */
-authorizations.get = async ({id, controller, invocationTarget}) => {
+authorizations.get = async ({id, controller, invocationTarget} = {}) => {
   assert.string(id, 'id');
   assert.optionalString(controller, 'controller');
   if(invocationTarget !== undefined) {
@@ -210,7 +208,7 @@ authorizations.find = async ({query = {}, fields = {}, options = {}}) => {
  * @return {Promise<Boolean>} resolves to `true` if a zcap was removed and
  *   `false` if not.
  */
-authorizations.remove = async ({controller, id}) => {
+authorizations.remove = async ({controller, id} = {}) => {
   assert.string(controller, 'controller');
   assert.string(id, 'id');
 
@@ -229,7 +227,7 @@ authorizations.remove = async ({controller, id}) => {
  *
  * @return {Promise<Object>} resolves to the database record.
  */
-zcaps.insert = async ({controller, referenceId, capability}) => {
+zcaps.insert = async ({controller, referenceId, capability} = {}) => {
   assert.string(controller, 'controller');
   assert.string(referenceId, 'referenceId');
   assert.object(capability, 'capability');
@@ -275,7 +273,7 @@ zcaps.insert = async ({controller, referenceId, capability}) => {
  *
  * @return {Promise<Object>} resolves to `{capability, meta}`.
  */
-zcaps.get = async ({controller, id, referenceId}) => {
+zcaps.get = async ({controller, id, referenceId} = {}) => {
   assert.string(controller, 'controller');
   assert.optionalString(id, 'id');
   assert.optionalString(referenceId, 'referenceId');
@@ -327,7 +325,7 @@ zcaps.find = async ({query = {}, fields = {}, options = {}}) => {
  * @return {Promise<Boolean>} resolves to `true` if a zcap was removed and
  *   `false` if not.
  */
-zcaps.remove = async ({controller, id, referenceId}) => {
+zcaps.remove = async ({controller, id, referenceId} = {}) => {
   assert.string(controller, 'controller');
   assert.optionalString(id, 'id');
   assert.optionalString(referenceId, 'referenceId');

--- a/test/mocha/.eslintrc
+++ b/test/mocha/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "assertNoError": true,
+    "should": true
+  }
+}

--- a/test/mocha/30-revocation.js
+++ b/test/mocha/30-revocation.js
@@ -1,0 +1,132 @@
+/*!
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brZcapStorage = require('bedrock-zcap-storage');
+const database = require('bedrock-mongodb');
+const mockData = require('./mock-data');
+const {util: {clone}} = require('bedrock');
+
+describe('revocation API', () => {
+  describe('insert API', () => {
+    it('properly inserts a revocation', async () => {
+      let err;
+      let result;
+      const revocation = clone(mockData.revocations.alpha);
+      try {
+        result = await brZcapStorage.revocations.insert(revocation);
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.capability.should.eql(revocation.capability);
+
+      const findResult = await database.collections['zcap-revocation'].find({
+        id: database.hash(revocation.capability.id),
+      }).toArray();
+      findResult.should.have.length(1);
+      findResult[0].capability.should.eql(revocation.capability);
+    });
+    it('returns DuplicateError on same id and delegator', async () => {
+
+      const revocation = clone(mockData.revocations.beta);
+
+      // insert beta revocation
+      await brZcapStorage.revocations.insert(revocation);
+
+      // attempt to insert same revocation again
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.revocations.insert(revocation);
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('DuplicateError');
+    });
+  });
+  describe('isRevoked API', () => {
+    let revocation;
+    before(async () => {
+      revocation = clone(mockData.revocations.alpha);
+      revocation.capability.id = '5acb9314-dd56-43c0-bb98-af6a940f69dc';
+      await brZcapStorage.revocations.insert(revocation);
+    });
+    it('returns true on a matching revocation', async () => {
+      const capabilities = [{
+        capabilityId: revocation.capability.id,
+        delegator: revocation.delegator,
+      }];
+      let result;
+      let err;
+      try {
+        result = await brZcapStorage.revocations.isRevoked({capabilities});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('boolean');
+      result.should.be.true;
+    });
+    it('returns false on unknown delegator', async () => {
+      const capabilities = [{
+        capabilityId: revocation.capability.id,
+        // an unknown delegator
+        delegator: '8eb105d5-59ed-47f1-8364-5c77258715a4',
+      }];
+      let result;
+      let err;
+      try {
+        result = await brZcapStorage.revocations.isRevoked({capabilities});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('boolean');
+      result.should.be.false;
+    });
+    it('returns false on unknown id', async () => {
+      const capabilities = [{
+        // an unknown id
+        capabilityId: '758444cb-007f-480d-a7be-273308fdd1b0',
+        delegator: revocation.delegator,
+      }];
+      let result;
+      let err;
+      try {
+        result = await brZcapStorage.revocations.isRevoked({capabilities});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('boolean');
+      result.should.be.false;
+    });
+    it('returns false on unknown id and delegator', async () => {
+      const capabilities = [{
+        // an unknown id
+        capabilityId: '758444cb-007f-480d-a7be-273308fdd1b0',
+        // an unknown delegator
+        delegator: '8eb105d5-59ed-47f1-8364-5c77258715a4',
+      }];
+      let result;
+      let err;
+      try {
+        result = await brZcapStorage.revocations.isRevoked({capabilities});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('boolean');
+      result.should.be.false;
+    });
+  });
+});

--- a/test/mocha/mock-data.js
+++ b/test/mocha/mock-data.js
@@ -1,0 +1,75 @@
+/*!
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const bedrock = require('bedrock');
+
+const mocks = {};
+module.exports = mocks;
+
+const actors = mocks.actors = {};
+const delegations = mocks.delegations = {};
+const revocations = mocks.revocations = {};
+
+actors.alpha = {
+  id: 'urn:uuid:ec6bcc36-e7ab-46e9-aebb-ab57caee4fbe'
+};
+
+actors.beta = {
+  id: 'urn:uuid:df29c22a-9c68-448c-a04b-345383aaf8ff'
+};
+
+delegations.alpha = {
+  // this corresponds to the bedrock-account ID
+  controller: 'urn:uuid:defa6262-6fa2-4eb4-a8a3-924580a47900',
+  domain: 'https://example.com',
+  // this is a profile ID, this is computed (eventually) by calling
+  // did-veres-one.foo to derive the DID from the verificationMethod in the
+  // proof.
+  delegator: 'did:v1:123123', // verificationMethod.controller
+  capability: {
+    '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
+    // this is a unique ID
+    id: `urn:zcap:056df9bc-93e2-4a0e-aa5a-d5217dcca018`,
+    // this is typically a did:key: or did:v1:
+    invoker: actors.beta.id,
+    // parentCapability could be root capability (e.g. a key or an LD
+    // document).
+    parentCapability:
+      'https://example.com/keys/c9dd4d64-f9b7-4ac2-968f-9416da723dca',
+    allowedAction: 'sign',
+    invocationTarget: {
+      // this is a public identifier for a key
+      verificationMethod: 'urn:uuid:c54a4a71-c6fb-43ea-b075-bf6abe67ebae',
+      id: 'https://example.com/keys/c9dd4d64-f9b7-4ac2-968f-9416da723dca',
+      type: 'Ed25519VerificationKey2018',
+    },
+    proof: {
+      // ...,
+      // deref verificationMethod to get its controller
+      verificationMethod: 'did:v1:123123#123123'
+    }
+  }
+};
+
+revocations.alpha = {
+  delegator: '51689f5c-a8ea-4924-8108-e7461a54989f',
+  capability: {
+    id: '5cef0111-04f3-4d6b-9a67-48d7013fea9a',
+  }
+};
+
+revocations.beta = {
+  delegator: '93ae803d-e753-4789-83a1-2b3e807abd7b',
+  capability: {
+    id: '8677f033-d4fd-44c6-afb2-a49688d68c21',
+  }
+};
+
+revocations.gamma = {
+  delegator: '3f1995e6-038b-41a2-9c87-70fd0458b74e',
+  capability: {
+    id: '2044302d-484b-4bfd-83c6-b7a8f988770d',
+  }
+};

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bedrock-zcap-storage-test",
+  "version": "0.0.1-0",
+  "description": "Bedrock ZCAP storage test",
+  "private": true,
+  "scripts": {
+    "test": "node --preserve-symlinks test.js test"
+  },
+  "dependencies": {
+    "bedrock": "^3.1.0",
+    "bedrock-jsonld-document-loader": "^1.0.1",
+    "bedrock-mongodb": "^6.0.2",
+    "bedrock-security-context": "^3.0.0",
+    "bedrock-test": "^5.0.0",
+    "bedrock-zcap-storage": "file:.."
+  }
+}

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {config} = require('bedrock');
+const path = require('path');
+
+config.mocha.tests.push(path.join(__dirname, 'mocha'));
+
+// mongodb config
+config.mongodb.name = 'bedrock_zcap_storage_test';
+config.mongodb.host = 'localhost';
+config.mongodb.port = 27017;
+// drop all collections on initialization
+config.mongodb.dropCollections = {};
+config.mongodb.dropCollections.onInit = true;
+config.mongodb.dropCollections.collections = [];

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+const bedrock = require('bedrock');
+require('bedrock-mongodb');
+require('bedrock-zcap-storage');
+require('bedrock-security-context');
+
+require('bedrock-test');
+bedrock.start();


### PR DESCRIPTION
@dlongley looking for the high sign that this is the right thing.

revocation API has `insert` and `get` methods modeled after the existing `authorization` collection.  Data structure is the same as well.

I'm stopping work here until I get feedback.