### PR TITLE
Add coverage tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-zcap-storage ChangeLog
 
+## 4.1.1 - 2021-11-29
+
+### Changed
+- Fixed bug with database functions that were not being properly awaited inside
+  `authorization.find` and `zcaps.get`.
+
+### Added
+- Added coverage tests in order to make sure all functions are working properly.
+
 ## 4.1.0 - 2021-11-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 4.1.1 - TBD
 
 ### Changed
-- Fixed bug with database functions that were not being properly awaited inside
+- Fix bug with database functions that were not being properly awaited inside
   `authorization.find` and `zcaps.get`.
 
 ### Added
-- Added coverage tests in order to make sure all functions are working properly.
+- Add coverage tests in order to make sure all functions are working properly.
 
 ## 4.1.0 - 2021-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-zcap-storage ChangeLog
 
-## 4.1.1 - 2021-11-29
+## 4.1.1 - TBD
 
 ### Changed
 - Fixed bug with database functions that were not being properly awaited inside

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -256,7 +256,7 @@ authorizations.remove = async ({controller, id, explain = false} = {}) => {
     return cursor.explain('executionStats');
   }
 
-  const result = collection.deleteMany(query);
+  const result = await collection.deleteMany(query);
   return result.result.n !== 0;
 };
 
@@ -343,10 +343,10 @@ zcaps.get = async ({controller, id, referenceId, explain = false} = {}) => {
     return cursor.explain('executionStats');
   }
 
-  const record = collection.findOne(query, {projection});
+  const record = await collection.findOne(query, {projection});
   if(!record) {
     throw new BedrockError(
-      'Authorization capability not found.',
+      'ZCap capability not found.',
       'NotFoundError',
       {controller, id, referenceId, httpStatusCode: 404, public: true});
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -346,7 +346,7 @@ zcaps.get = async ({controller, id, referenceId, explain = false} = {}) => {
   const record = await collection.findOne(query, {projection});
   if(!record) {
     throw new BedrockError(
-      'ZCap capability not found.',
+      'Authorization capability not found.',
       'NotFoundError',
       {controller, id, referenceId, httpStatusCode: 404, public: true});
   }

--- a/test/mocha/10-authorization.js
+++ b/test/mocha/10-authorization.js
@@ -91,7 +91,7 @@ describe('authorization API', () => {
       should.exist(err);
       err.name.should.equal('DuplicateError');
     });
-    it(`returns TypeError when 'invocationTarget.id' is not a string `,
+    it(`returns TypeError when 'invocationTarget.id' is not a string`,
       async () => {
         let err;
         let result;
@@ -110,11 +110,8 @@ describe('authorization API', () => {
         should.not.exist(result);
         should.exist(err);
         err.name.should.equal('TypeError');
-        err.message.should.equal('"capability.invocationTarget" must be a ' +
-          'string or an object with where "capability.invocationTarget.id" ' +
-          'is a string.');
       });
-    it(`returns Error when 'invocationTarget' is not an absolute URI `,
+    it(`returns Error when 'invocationTarget' is not an absolute URI`,
       async () => {
         let err;
         let result;
@@ -131,8 +128,6 @@ describe('authorization API', () => {
         should.not.exist(result);
         should.exist(err);
         err.name.should.equal('Error');
-        err.message.should.equal('The ID of the capability\'s invocation ' +
-          'target must be an absolute URI.');
       });
   });
   describe('get API', async () => {
@@ -225,8 +220,6 @@ describe('authorization API', () => {
       should.not.exist(result);
       should.exist(err);
       err.name.should.equal('TypeError');
-      err.message.should.equal('Either "controller" or "invocationTarget" ' +
-        'must be given.');
     });
     it('returns NotFoundError when no authorization is found', async () => {
       let err;
@@ -242,7 +235,6 @@ describe('authorization API', () => {
       should.not.exist(result);
       should.exist(err);
       err.name.should.equal('NotFoundError');
-      err.message.should.equal('Authorization capability not found.');
     });
   });
   describe('find API', async () => {

--- a/test/mocha/10-authorization.js
+++ b/test/mocha/10-authorization.js
@@ -1,0 +1,307 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brZcapStorage = require('bedrock-zcap-storage');
+const database = require('bedrock-mongodb');
+const mockData = require('./mock-data');
+const {util: {clone}} = require('bedrock');
+const helpers = require('./helpers.js');
+
+describe('authorization API', () => {
+  describe('insert API', async () => {
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-authorization';
+      await helpers.removeCollection(collectionName);
+    });
+    it('properly inserts an authorization', async () => {
+      let err;
+      let result;
+      const authorization = clone(mockData.authorizations.alpha);
+      try {
+        result = await brZcapStorage.authorizations.insert({
+          controller: authorization.controller,
+          capability: authorization.capability
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.authorization.should.eql(authorization);
+
+      const collection = database.collections['zcap-storage-authorization'];
+      const findResult = await collection.find({
+        controller: helpers.hash(authorization.controller),
+        id: helpers.hash(authorization.capability.id)
+      }).toArray();
+      findResult.should.have.length(1);
+      findResult[0].authorization.should.eql(authorization);
+    });
+    it(`properly inserts an authorization with 'invocationTarget' being an ` +
+      'object', async () => {
+      let err;
+      let result;
+      const authorization = clone(mockData.authorizations.alpha);
+      authorization.capability.invocationTarget = {
+        id: 'urn:uuid:e30d372c-7ab2-429c-91b0-03dc3bcc6289'
+      };
+      try {
+        result = await brZcapStorage.authorizations.insert({
+          controller: authorization.controller,
+          capability: authorization.capability
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.authorization.should.eql(authorization);
+
+      const collection = database.collections['zcap-storage-authorization'];
+      const findResult = await collection.find({
+        controller: helpers.hash(authorization.controller),
+        id: helpers.hash(authorization.capability.id)
+      }).toArray();
+      findResult.should.have.length(1);
+      findResult[0].authorization.should.eql(authorization);
+    });
+    it(`returns DuplicateError on same 'id' and 'controller'`, async () => {
+      const authorization = clone(mockData.authorizations.alpha);
+
+      // insert alpha authorization
+      await brZcapStorage.authorizations.insert({
+        controller: authorization.controller,
+        capability: authorization.capability
+      });
+
+      // attempt to insert same authorization again
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.authorizations.insert({
+          controller: authorization.controller,
+          capability: authorization.capability
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('DuplicateError');
+    });
+    it(`returns TypeError when 'invocationTarget.id' is not a string `,
+      async () => {
+        let err;
+        let result;
+        const authorization = clone(mockData.authorizations.alpha);
+        authorization.capability.invocationTarget = {
+          id: {}
+        };
+        try {
+          result = await brZcapStorage.authorizations.insert({
+            controller: authorization.controller,
+            capability: authorization.capability
+          });
+        } catch(e) {
+          err = e;
+        }
+        should.not.exist(result);
+        should.exist(err);
+        err.name.should.equal('TypeError');
+        err.message.should.equal('"capability.invocationTarget" must be a ' +
+          'string or an object with where "capability.invocationTarget.id" ' +
+          'is a string.');
+      });
+    it(`returns Error when 'invocationTarget' is not an absolute URI `,
+      async () => {
+        let err;
+        let result;
+        const authorization = clone(mockData.authorizations.alpha);
+        authorization.capability.invocationTarget = '123456';
+        try {
+          result = await brZcapStorage.authorizations.insert({
+            controller: authorization.controller,
+            capability: authorization.capability
+          });
+        } catch(e) {
+          err = e;
+        }
+        should.not.exist(result);
+        should.exist(err);
+        err.name.should.equal('Error');
+        err.message.should.equal('The ID of the capability\'s invocation ' +
+          'target must be an absolute URI.');
+      });
+  });
+  describe('get API', async () => {
+    let authorization;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-authorization';
+      await helpers.removeCollection(collectionName);
+
+      authorization = clone(mockData.authorizations.alpha);
+      await brZcapStorage.authorizations.insert({
+        controller: authorization.controller,
+        capability: authorization.capability
+      });
+    });
+    it(`properly gets an authorization with 'controller' and 'id'`,
+      async () => {
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.authorizations.get({
+            controller: authorization.controller,
+            id: authorization.capability.id
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.authorization.should.eql(authorization);
+      });
+    it(`properly gets an authorization with 'invocationTarget' and 'id'`,
+      async () => {
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.authorizations.get({
+            id: authorization.capability.id,
+            invocationTarget: authorization.capability.invocationTarget
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.authorization.should.eql(authorization);
+      });
+    it(`properly gets an authorization with 'invocationTarget' an array of ` +
+      `strings and 'id'`, async () => {
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.authorizations.get({
+          id: authorization.capability.id,
+          invocationTarget: [authorization.capability.invocationTarget]
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.authorization.should.eql(authorization);
+    });
+    it(`returns AssertionError when 'invocationTarget' is not a string ` +
+      'or array of strings', async () => {
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.authorizations.get({
+          id: authorization.capability.id,
+          invocationTarget: {}
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('AssertionError');
+    });
+    it(`returns TypeError when no 'invocationTarget' or 'controller' ` +
+      'is provided', async () => {
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.authorizations.get({
+          id: authorization.capability.id
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('TypeError');
+      err.message.should.equal('Either "controller" or "invocationTarget" ' +
+        'must be given.');
+    });
+    it('returns NotFoundError when no authorization is found', async () => {
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.authorizations.get({
+          controller: authorization.controller,
+          id: '123456'
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('NotFoundError');
+      err.message.should.equal('Authorization capability not found.');
+    });
+  });
+  describe('find API', async () => {
+    let authorization;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-authorization';
+      await helpers.removeCollection(collectionName);
+
+      authorization = clone(mockData.authorizations.alpha);
+      await brZcapStorage.authorizations.insert({
+        controller: authorization.controller,
+        capability: authorization.capability
+      });
+    });
+    it(`properly finds an authorization with a 'query'`,
+      async () => {
+        let err;
+        let result;
+        try {
+          const query = {
+            controller: helpers.hash(authorization.controller),
+            id: helpers.hash(authorization.capability.id)
+          };
+          result = await brZcapStorage.authorizations.find({query});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result[0].authorization.should.eql(authorization);
+      });
+  });
+  describe('remove API', async () => {
+    let authorization;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-authorization';
+      await helpers.removeCollection(collectionName);
+
+      authorization = clone(mockData.authorizations.alpha);
+      await brZcapStorage.authorizations.insert({
+        controller: authorization.controller,
+        capability: authorization.capability
+      });
+    });
+    it(`properly removes an authorization with a 'controller' and 'id'`,
+      async () => {
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.authorizations.remove({
+            controller: authorization.controller,
+            id: authorization.capability.id
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.equal(true);
+      });
+  });
+});

--- a/test/mocha/20-zcaps.js
+++ b/test/mocha/20-zcaps.js
@@ -1,0 +1,258 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brZcapStorage = require('bedrock-zcap-storage');
+const database = require('bedrock-mongodb');
+const mockData = require('./mock-data');
+const {util: {clone}} = require('bedrock');
+const helpers = require('./helpers.js');
+
+describe('zcaps API', () => {
+  describe('insert API', async () => {
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-zcap';
+      await helpers.removeCollection(collectionName);
+    });
+    it('properly inserts a zcap', async () => {
+      let err;
+      let result;
+      const zcap = clone(mockData.zcaps.alpha);
+      const {controller, referenceId, capability} = zcap;
+      try {
+        result = await brZcapStorage.zcaps.insert({
+          controller,
+          referenceId,
+          capability
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.controller.should.equal(helpers.hash(controller));
+      result.id.should.eql(helpers.hash(capability.id));
+
+      const collection = database.collections['zcap-storage-zcap'];
+      const findResult = await collection.find({
+        controller: helpers.hash(controller),
+        id: helpers.hash(capability.id),
+      }).toArray();
+      findResult.should.have.length(1);
+      findResult[0].controller.should.eql(helpers.hash(controller));
+      findResult[0].id.should.eql(helpers.hash(capability.id));
+    });
+    it(`returns DuplicateError on same 'controller', 'referenceId' and ` +
+      `'capability'`, async () => {
+      const zcap = clone(mockData.zcaps.alpha);
+      const {controller, referenceId, capability} = zcap;
+
+      // insert alpha zcap
+      await brZcapStorage.zcaps.insert({
+        controller,
+        referenceId,
+        capability
+      });
+
+      // attempt to insert same zcap again
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.zcaps.insert({
+          controller,
+          referenceId,
+          capability
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('DuplicateError');
+    });
+  });
+  describe('get API', async () => {
+    let zcap;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-zcap';
+      await helpers.removeCollection(collectionName);
+
+      zcap = clone(mockData.zcaps.alpha);
+      const {controller, referenceId, capability} = zcap;
+      await brZcapStorage.zcaps.insert({
+        controller,
+        referenceId,
+        capability
+      });
+    });
+    it(`properly gets a zcap with 'controller' and 'id'`,
+      async () => {
+        const {controller, capability} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.get({
+            controller,
+            id: capability.id
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.capability.should.eql(capability);
+      });
+    it(`properly gets a zcap with 'controller' and 'referenceId'`,
+      async () => {
+        const {controller, referenceId, capability} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.get({
+            controller,
+            referenceId
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.capability.should.eql(capability);
+      });
+    it(`returns TypeError when no 'id' or 'referenceId' is provided`,
+      async () => {
+        const {controller} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.get({
+            controller
+          });
+        } catch(e) {
+          err = e;
+        }
+        should.not.exist(result);
+        should.exist(err);
+        err.name.should.equal('TypeError');
+        err.message.should.equal('Either "id" or "referenceId" must be given.');
+      });
+    it('returns NotFoundError when no zcap is found', async () => {
+      const {capability} = zcap;
+      let err;
+      let result;
+      try {
+        result = await brZcapStorage.zcaps.get({
+          controller: '123456',
+          id: capability.id
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.name.should.equal('NotFoundError');
+      err.message.should.equal('ZCap capability not found.');
+    });
+  });
+  describe('find API', async () => {
+    let zcap;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-zcap';
+      await helpers.removeCollection(collectionName);
+
+      zcap = clone(mockData.zcaps.alpha);
+      const {controller, referenceId, capability} = zcap;
+      await brZcapStorage.zcaps.insert({
+        controller,
+        referenceId,
+        capability
+      });
+    });
+    it(`properly finds a zcap with a 'query'`,
+      async () => {
+        const {controller, capability} = zcap;
+        let err;
+        let result;
+        try {
+          const query = {
+            controller: helpers.hash(controller),
+            id: helpers.hash(capability.id)
+          };
+          result = await brZcapStorage.zcaps.find({query});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result[0].controller.should.eql(helpers.hash(controller));
+        result[0].id.should.eql(helpers.hash(capability.id));
+      });
+  });
+  describe('remove API', async () => {
+    let zcap;
+    beforeEach(async () => {
+      const collectionName = 'zcap-storage-zcap';
+      await helpers.removeCollection(collectionName);
+
+      zcap = clone(mockData.zcaps.alpha);
+      const {controller, referenceId, capability} = zcap;
+      await brZcapStorage.zcaps.insert({
+        controller,
+        referenceId,
+        capability
+      });
+    });
+    it(`properly removes a zcap with a 'controller' and 'id'`,
+      async () => {
+        const {controller, capability} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.remove({
+            controller,
+            id: capability.id
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.equal(true);
+      });
+    it(`properly removes a zcap with a 'controller' and 'referenceId'`,
+      async () => {
+        const {controller, referenceId} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.remove({
+            controller,
+            referenceId
+          });
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.equal(true);
+      });
+    it(`returns TypeError when no 'id' or 'referenceId' is provided`,
+      async () => {
+        const {controller} = zcap;
+        let err;
+        let result;
+        try {
+          result = await brZcapStorage.zcaps.remove({
+            controller
+          });
+        } catch(e) {
+          err = e;
+        }
+        should.not.exist(result);
+        should.exist(err);
+        err.name.should.equal('TypeError');
+        err.message.should.equal('Either "id" or "referenceId" must be given.');
+      });
+  });
+});

--- a/test/mocha/20-zcaps.js
+++ b/test/mocha/20-zcaps.js
@@ -135,7 +135,6 @@ describe('zcaps API', () => {
         should.not.exist(result);
         should.exist(err);
         err.name.should.equal('TypeError');
-        err.message.should.equal('Either "id" or "referenceId" must be given.');
       });
     it('returns NotFoundError when no zcap is found', async () => {
       const {capability} = zcap;
@@ -152,7 +151,6 @@ describe('zcaps API', () => {
       should.not.exist(result);
       should.exist(err);
       err.name.should.equal('NotFoundError');
-      err.message.should.equal('ZCap capability not found.');
     });
   });
   describe('find API', async () => {
@@ -252,7 +250,6 @@ describe('zcaps API', () => {
         should.not.exist(result);
         should.exist(err);
         err.name.should.equal('TypeError');
-        err.message.should.equal('Either "id" or "referenceId" must be given.');
       });
   });
 });

--- a/test/mocha/mock-data.js
+++ b/test/mocha/mock-data.js
@@ -14,6 +14,9 @@ const revocations = mocks.revocations = {};
 const authorizations = mocks.authorizations = {};
 const zcaps = mocks.zcaps = {};
 
+const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + 1);
+
 actors.alpha = {
   id: 'urn:uuid:ec6bcc36-e7ab-46e9-aebb-ab57caee4fbe'
 };
@@ -79,6 +82,7 @@ revocations.gamma = {
   delegator: '3f1995e6-038b-41a2-9c87-70fd0458b74e',
   capability: {
     id: '2044302d-484b-4bfd-83c6-b7a8f988770d',
+    expires: tomorrow
   }
 };
 


### PR DESCRIPTION
- Increases coverage to 98.39%.
- Codecov: https://app.codecov.io/gh/digitalbazaar/bedrock-zcap-storage/branch/update-test-coverage
- Also fixes bug with database functions that were not being properly
awaited inside `authorization.find` and `zcaps.get`.