### PR TITLE
Use `controller` field from `capability` instead of `invoker`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-zcap-storage ChangeLog
 
+## 5.0.0 - 2022-01-xx
+
+### Changed
+- **BREAKING**: Get `invoker` for internal indexing from
+  `capability.controller` and require `capability.controller` field to be set.
+
 ## 4.1.1 - 2021-12-14
 
 ### Changed

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -275,7 +275,7 @@ zcaps.insert = async ({controller, referenceId, capability} = {}) => {
   assert.string(referenceId, 'referenceId');
   assert.object(capability, 'capability');
   assert.string(capability.id, 'capability.id');
-  assert.string(capability.invoker, 'capability.invoker');
+  assert.string(capability.controller, 'capability.controller');
 
   // insert the capability and get the updated record
   const now = Date.now();
@@ -283,7 +283,7 @@ zcaps.insert = async ({controller, referenceId, capability} = {}) => {
   const record = {
     id: database.hash(capability.id),
     controller: database.hash(controller),
-    invoker: database.hash(capability.invoker),
+    invoker: database.hash(capability.controller),
     referenceId: database.hash(referenceId),
     meta,
     capability

--- a/test/mocha/40-database.js
+++ b/test/mocha/40-database.js
@@ -132,7 +132,7 @@ describe('ZCaps Database Tests', () => {
           referenceId: uuid(),
           capability: {
             id: uuid(),
-            invoker: uuid(),
+            controller: uuid(),
             invocationTarget: uuid()
           }});
       }
@@ -210,7 +210,7 @@ describe('ZCaps Database Tests', () => {
         const {capability, controller} = mockData.zcaps.alpha;
         const query = {
           controller: helpers.hash(controller),
-          invoker: helpers.hash(capability.invoker)
+          invoker: helpers.hash(capability.controller)
         };
         const {executionStats} = await brZcapStorage.zcaps.find({
           query,

--- a/test/mocha/mock-data.js
+++ b/test/mocha/mock-data.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2022 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -38,18 +38,14 @@ delegations.alpha = {
     // this is a unique ID
     id: `urn:zcap:056df9bc-93e2-4a0e-aa5a-d5217dcca018`,
     // this is typically a did:key: or did:v1:
-    invoker: actors.alpha.id,
+    controller: actors.alpha.id,
     // parentCapability could be root capability (e.g. a key or an LD
     // document).
     parentCapability:
       'https://example.com/keys/c9dd4d64-f9b7-4ac2-968f-9416da723dca',
     allowedAction: 'sign',
-    invocationTarget: {
-      // this is a public identifier for a key
-      verificationMethod: 'urn:uuid:c54a4a71-c6fb-43ea-b075-bf6abe67ebae',
-      id: 'https://example.com/keys/c9dd4d64-f9b7-4ac2-968f-9416da723dca',
-      type: 'Ed25519VerificationKey2018',
-    },
+    invocationTarget:
+      'https://example.com/keys/c9dd4d64-f9b7-4ac2-968f-9416da723dca',
     proof: {
       // ...,
       // deref verificationMethod to get its controller
@@ -91,7 +87,7 @@ authorizations.alpha = {
   capability: {
     '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
     id: 'urn:zcap:3b175c87-09ee-44a4-9c97-dc2ffb329b22',
-    invoker: actors.alpha.id,
+    controller: actors.alpha.id,
     parentCapability:
       'https://example.com/keys/c2ed35fd-d8fe-4180-a5f5-a2eec739036b',
     allowedAction: 'sign',
@@ -107,7 +103,7 @@ authorizations.beta = {
   capability: {
     '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
     id: 'urn:zcap:8bd184b4-a7bd-4ca3-a450-9f7d1e10eedd',
-    invoker: actors.alpha.id,
+    controller: actors.alpha.id,
     parentCapability:
       'https://example.com/keys/8b02af9e-abcb-4337-967a-987ed80329e7',
     allowedAction: 'sign',
@@ -124,7 +120,7 @@ zcaps.alpha = {
   capability: {
     '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
     id: 'urn:zcap:c10e705a-9921-4517-98ca-f776bcb6e39b',
-    invoker: actors.alpha.id,
+    controller: actors.alpha.id,
     parentCapability:
       'https://example.com/keys/d6de2aef-d4ed-4d89-a794-d43cc185844b',
     allowedAction: 'sign',


### PR DESCRIPTION
Additional changes may be needed before doing a major release (TBD by checking this module against top-level apps, once upgraded).